### PR TITLE
Modif neuron

### DIFF
--- a/include/Neuron.hpp
+++ b/include/Neuron.hpp
@@ -49,7 +49,8 @@ class Neuron {
     double ext_f_; ///>external frequency
     
     double t_;
-    std::priority_queue <Event> events_in_;
+    std::priority_queue <Event> events_in_; /* Ce serait plus simple d'avoir une seule queue d'event pour chaque neuron
+    et de faire appel à la queue des neurones suivants lors d'un spike*/
     std::priority_queue <Event> events_out_;
     std::vector <Neuron*> synapses_;
     

--- a/src/neuron.cpp
+++ b/src/neuron.cpp
@@ -14,7 +14,7 @@ Physics::Amplitude const Neuron::amplitude_= 0.1;
 Neuron::Neuron(bool const& exc, double const& eps, double const& ext_f)
 : excitatory_(exc), inhib_connections_(250), excit_connections_(1000), epsilon_(eps), tau_(20), ext_f_(ext_f), t_(0)
 {
-    synapses_ = std::vector<Neuron*>(1250);
+    synapses_ = std::vector<Neuron*>(1250); /* Synapse = connections cotés axon terminal? */
     std::priority_queue <Event> ev;
     events_in_ = ev;
     events_out_ = ev;


### PR DESCRIPTION
Ce serait peut-être plus simple que chaque Neuron n'ait **qu'une seule** queue d'Event (_équivalente à votre queue d'Event inputs_) et que lorsqu'un Neuron spike il fasse appel à une méthode add_event pour ajouter un Event à la queue d'Event **de chaque Neuron auquel il est connecté** (coté axon terminal = output)

dites-nous ce que vous en penser :smiling_imp: