### PR TITLE
tested UpdateRI, AddEventIn and SetConnections in ExplicitNeuronTest

### DIFF
--- a/apps/explicit_fixed_step/main.cpp
+++ b/apps/explicit_fixed_step/main.cpp
@@ -40,18 +40,8 @@ int main (int argc, char** argv)
 	} catch (TCLAP::ArgException &e)  // catch any exceptions
 	{ std::cerr << "error: " << e.error() << " for arg " << e.argId() << std::endl; }
     
-    //création d'un neuron "test"
-    Neuron neurone(Type::Explicit, true, 1, 1, 2);
     
-    neurone.step_explicit(1);
     
-    std::cout<<"Step_explicit fonctionne"<<std::endl; //fonctionne bien
-    
-    neurone.step(1);
-    
-    std::cout<<"Step fonctionne bien" <<std::endl; //fonctionne bien
-    
-    Neuron neurone2(Type::Explicit, true, 1, 1, 2);
 }
 /*
  * Si on ne spécifie rien en lançant le programme, voici la sortie :

--- a/include/Neuron.hpp
+++ b/include/Neuron.hpp
@@ -14,7 +14,8 @@ class Neuron {
     
     //constructeur et destructeur
     Neuron(Type const& a_type, bool const& exc, double const& eps,
-			double const& ext_f, Physics::Resistance const& membrane_resistance, double Vm = 0, double I = 0); ///< constructor takes arguments that will be modified during time 
+			double const& ext_f, Physics::Resistance const& membrane_resistance, double Vm = 0, double I = 0, 
+			Physics::Time refractory_period_ = 0, Physics::Time t_ = 0); ///< constructor takes arguments that will be modified during time 
 
  
 
@@ -34,16 +35,14 @@ class Neuron {
     double get_Vm() const; 
     double get_I() const; 
     Physics::Time get_t() const;	///<returns the time of the neuron
-   
-
-    
-    private :
-    //méthodes privées
     void input(Physics::Time const& dt); ///< uses function of dirac to know if the current has been added and updates Vm
     void output(double const& x); ///< updates the output
     void add_event_in(Event const& ev);
+    int get_synapses_size() const;
+    int get_event_in_size() const;
     
-   
+    private:
+    
     //attributs
     Type type_;
     static unsigned int neuron_id_;

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -41,6 +41,12 @@ Network::~Network()
 {
 	raster_plot_file->close();
         delete raster_plot_file;
+        
+    for (auto& neuron : neurons_)
+    {
+		neuron = nullptr;
+	}
+	neurons_.clear();
 }
 
 void Network::make_connections()

--- a/src/Neuron.cpp
+++ b/src/Neuron.cpp
@@ -15,9 +15,9 @@ using namespace std;
 
 
 Neuron::Neuron(Type const& a_type, bool const& exc, double const& eps,
-				double const& ext_f, Physics::Resistance const& membrane_resistance, double Vm, double I)
+				double const& ext_f, Physics::Resistance const& membrane_resistance, double Vm, double I, Physics::Time refractory_period, Physics::Time t)
 				: type_(a_type), excitatory_(exc), inhib_connections_(250), excit_connections_(1000),
-				epsilon_(eps), ext_f_(ext_f), t_(0), membrane_resistance_(membrane_resistance), Vm_(Vm), I_(I)
+				epsilon_(eps), ext_f_(ext_f), membrane_resistance_(membrane_resistance), Vm_(Vm), I_(I), refractory_period_(refractory_period), t_(t)
 
 {
     synapses_ = std::vector<Neuron*>(1250);
@@ -40,13 +40,7 @@ Neuron::Neuron(Type const& a_type, bool const& exc, double const& eps,
 
 
 Neuron::~Neuron()
-{
-    for (auto& element : synapses_) {
-        delete element;
-        element = nullptr;
-    }
-    synapses_.clear();
-    
+{  
     neuron_file->close();
     delete neuron_file;
 }
@@ -210,13 +204,15 @@ void Neuron::update_RI(Physics::Time const& dt)
 
 	else if ((type_ == Type::Explicit) or (type_ == Type::Implicit))
 	{
-
-		while((events_in_.top().get_t() < (t_ + dt)) && (refractory_period_ == 0))
+        
+		while((!events_in_.empty()) && (events_in_.top().get_t() < (t_ + dt)) && (refractory_period_ == 0))
 		{
+		   
 		// si la différence entre le temps courant et (transmission_delay_ + temps où le courant a été envoyé) = 0
 		// la fonction de dirac retourne 1 et dans ce cas on incrémente le courant
 			if (Physics::dirac_distribution(t_- transmission_delay_ - events_in_.top().get_t()) == 1)
 			{
+				
 				I_ += amplitude_ / membrane_resistance_;
 				events_in_.pop();
 
@@ -246,4 +242,14 @@ double Neuron::get_I() const
 {
 	return I_;
 
+}
+
+int Neuron::get_synapses_size() const
+{
+	return synapses_.size();
+}
+
+int Neuron::get_event_in_size() const
+{
+	return events_in_.size();
 }

--- a/test/ExplicitNeuronTest.cpp
+++ b/test/ExplicitNeuronTest.cpp
@@ -47,23 +47,69 @@ TEST(ExplicitNeuronTests, TestResetPotential)
     EXPECT_TRUE(result==10);
 }
 
-/*TEST(ExplicitNeuronTests, TestSetConnections)
+TEST(ExplicitNeuronTests, TestSetConnections)
 {
-    Neuron neurone1(Type::Explicit, true, 1, 1, 3);
-    Neuron neurone2(Type::Explicit, true, 1, 1, 3);
-    neurone1.set_Vm_ (25);
-    neurone1.set_I_ (10);
-    neurone2.set_Vm_(25);
-    neurone2.set_I_(10);
+    Neuron neurone1(Type::Explicit, true, 1, 1, 3, 25, 10);
+    Neuron neurone2(Type::Explicit, true, 1, 1, 3, 25, 10);
     int dt(1);
     neurone1.Neuron::set_connection(&neurone2);
     
-    int result = neurone1.synapses_.size();
+    int result = neurone1.get_synapses_size();
 
     EXPECT_EQ (1251, result); //initial size is 1250
     EXPECT_TRUE(result==1251);
 }
+
+TEST(ExplicitNeuronTests, TestAddEvent)
+{
+    Neuron neuron1(Type::Explicit, true, 1, 1, 1, 25, 10, 3);
+   
+    Event event1(1, 1.0);
+    
+    neuron1.add_event_in(event1);
+    int result = neuron1.get_event_in_size();
+    
+    EXPECT_EQ (1, result); //initial size is 0
+    EXPECT_TRUE(result==1);
+}
+
+
+
+TEST(ExplicitNeuronTests, TestUpdate_RI)
+{
+    Neuron neuron1(Type::Explicit, true, 1, 1, 1, 25, 10, 0, 3);
+   
+    Event event1(1, 1.0);
+    
+    neuron1.add_event_in(event1);
+    
+    int dt(3);
+    neuron1.update_RI(dt);
+    
+    
+    double result = neuron1.get_I();
+    
+    EXPECT_NEAR (10.1, neuron1.get_I(),  0.000001);   //initial current = 10 and membrane_resistance = 1
+    EXPECT_TRUE(abs(neuron1.get_I() - 10.1) < 0.000001);
+}
+
+/*TEST(ExplicitNeuronTests, TestOutput)
+{
+    Neuron neuron1(Type::Explicit, true, 1, 1, 1, 25, 10, 0, 3);
+    Neuron neuron2(Type::Explicit, true, 1, 1, 1, 25, 10, 0, 3);
+   
+    double i(10.0);
+
+    neuron1.Neuron::set_connection(&neuron2);   //ajout de neuron2 au tableau de synapses de neuron1
+    neuron1.output(i);                          //ajoute un event à neuron2
+    int result = neuron2.get_event_in_size();
+    
+    EXPECT_EQ (1, result); //initial size is 0
+    EXPECT_TRUE(result==1);
+    
+}
 */
+
   
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
Added getters for the size of synapses_ and events_in, in order to test UpdateRI, AddEventIn and SetConnections in ExplicitNeuronTest, moved the destruction of neurons from Neuron to Network, modified the constructor of Neuron by adding t_ and refractory_period_ in order to test.